### PR TITLE
fix(s3-images): s3 images not loading in admin panel

### DIFF
--- a/config/middlewares.js
+++ b/config/middlewares.js
@@ -1,6 +1,16 @@
-module.exports = [
+module.exports = ({ env }) => [
   'strapi::errors',
-  'strapi::security',
+  {
+    name: 'strapi::security',
+    config: {
+      contentSecurityPolicy: {
+        directives: {
+          'script-src': ["'self'", "'unsafe-inline'"],
+          'img-src': ["'self'", 'data:', 'strapi.io', `${env('AWS_BUCKET')}.s3.${env('AWS_REGION')}.amazonaws.com`],
+        },
+      }
+    },
+  },
   'strapi::cors',
   'strapi::poweredBy',
   'strapi::logger',


### PR DESCRIPTION
Images was not loading when inside the strapi admin panel. 

And error with "Content-Security-Policy img-src" was been logged